### PR TITLE
Add more endpoints

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,4 +9,4 @@ require "rubocop/rake_task"
 
 RuboCop::RakeTask.new
 
-task default: %i[spec rubocop]
+task default: %i[rubocop spec]

--- a/lib/cyprus_postal_codes.rb
+++ b/lib/cyprus_postal_codes.rb
@@ -11,4 +11,5 @@ module CyprusPostalCodes
   autoload :Districts, "cyprus_postal_codes/client/districts"
   autoload :Search, "cyprus_postal_codes/client/search"
   autoload :GovernmentServices, "cyprus_postal_codes/client/government_services"
+  autoload :PostOfficeBoxes, "cyprus_postal_codes/client/post_office_boxes"
 end

--- a/lib/cyprus_postal_codes.rb
+++ b/lib/cyprus_postal_codes.rb
@@ -9,4 +9,5 @@ module CyprusPostalCodes
   autoload :Paginator, "cyprus_postal_codes/client/paginator"
   autoload :Areas, "cyprus_postal_codes/client/areas"
   autoload :Districts, "cyprus_postal_codes/client/districts"
+  autoload :Search, "cyprus_postal_codes/client/search"
 end

--- a/lib/cyprus_postal_codes.rb
+++ b/lib/cyprus_postal_codes.rb
@@ -10,4 +10,5 @@ module CyprusPostalCodes
   autoload :Areas, "cyprus_postal_codes/client/areas"
   autoload :Districts, "cyprus_postal_codes/client/districts"
   autoload :Search, "cyprus_postal_codes/client/search"
+  autoload :GovernmentServices, "cyprus_postal_codes/client/government_services"
 end

--- a/lib/cyprus_postal_codes.rb
+++ b/lib/cyprus_postal_codes.rb
@@ -3,15 +3,15 @@
 require_relative "cyprus_postal_codes/version"
 
 module CyprusPostalCodes
-  autoload :Client, "cyprus_postal_codes/client"
-  autoload :Error, "cyprus_postal_codes/error"
   autoload :Addresses, "cyprus_postal_codes/client/addresses"
-  autoload :Paginator, "cyprus_postal_codes/client/paginator"
   autoload :Areas, "cyprus_postal_codes/client/areas"
+  autoload :Client, "cyprus_postal_codes/client"
   autoload :Districts, "cyprus_postal_codes/client/districts"
-  autoload :Search, "cyprus_postal_codes/client/search"
+  autoload :Error, "cyprus_postal_codes/error"
   autoload :GovernmentServices, "cyprus_postal_codes/client/government_services"
-  autoload :PostOfficeBoxes, "cyprus_postal_codes/client/post_office_boxes"
-  autoload :Parcel24Locations, "cyprus_postal_codes/client/parcel24_locations"
   autoload :OccupiedAreas, "cyprus_postal_codes/client/occupied_areas"
+  autoload :Paginator, "cyprus_postal_codes/client/paginator"
+  autoload :Parcel24Locations, "cyprus_postal_codes/client/parcel24_locations"
+  autoload :PostOfficeBoxes, "cyprus_postal_codes/client/post_office_boxes"
+  autoload :Search, "cyprus_postal_codes/client/search"
 end

--- a/lib/cyprus_postal_codes.rb
+++ b/lib/cyprus_postal_codes.rb
@@ -13,4 +13,5 @@ module CyprusPostalCodes
   autoload :GovernmentServices, "cyprus_postal_codes/client/government_services"
   autoload :PostOfficeBoxes, "cyprus_postal_codes/client/post_office_boxes"
   autoload :Parcel24Locations, "cyprus_postal_codes/client/parcel24_locations"
+  autoload :OccupiedAreas, "cyprus_postal_codes/client/occupied_areas"
 end

--- a/lib/cyprus_postal_codes.rb
+++ b/lib/cyprus_postal_codes.rb
@@ -12,4 +12,5 @@ module CyprusPostalCodes
   autoload :Search, "cyprus_postal_codes/client/search"
   autoload :GovernmentServices, "cyprus_postal_codes/client/government_services"
   autoload :PostOfficeBoxes, "cyprus_postal_codes/client/post_office_boxes"
+  autoload :Parcel24Locations, "cyprus_postal_codes/client/parcel24_locations"
 end

--- a/lib/cyprus_postal_codes/client.rb
+++ b/lib/cyprus_postal_codes/client.rb
@@ -6,14 +6,14 @@ require "faraday_middleware"
 module CyprusPostalCodes
   class Client
     include Addresses
-    include Paginator
     include Areas
     include Districts
-    include Search
     include GovernmentServices
-    include PostOfficeBoxes
-    include Parcel24Locations
     include OccupiedAreas
+    include Paginator
+    include Parcel24Locations
+    include PostOfficeBoxes
+    include Search
 
     BASE_URL = "https://cypruspost.post/api/postal-codes/"
 

--- a/lib/cyprus_postal_codes/client.rb
+++ b/lib/cyprus_postal_codes/client.rb
@@ -13,6 +13,7 @@ module CyprusPostalCodes
     include GovernmentServices
     include PostOfficeBoxes
     include Parcel24Locations
+    include OccupiedAreas
 
     BASE_URL = "https://cypruspost.post/api/postal-codes/"
 

--- a/lib/cyprus_postal_codes/client.rb
+++ b/lib/cyprus_postal_codes/client.rb
@@ -11,6 +11,7 @@ module CyprusPostalCodes
     include Districts
     include Search
     include GovernmentServices
+    include PostOfficeBoxes
 
     BASE_URL = "https://cypruspost.post/api/postal-codes/"
 

--- a/lib/cyprus_postal_codes/client.rb
+++ b/lib/cyprus_postal_codes/client.rb
@@ -33,10 +33,6 @@ module CyprusPostalCodes
       @last_response if defined?(@last_response)
     end
 
-    def inspect
-      "#<CyprusPostalCodes::Client>"
-    end
-
     def default_params
       { lng: lng }
     end

--- a/lib/cyprus_postal_codes/client.rb
+++ b/lib/cyprus_postal_codes/client.rb
@@ -12,6 +12,7 @@ module CyprusPostalCodes
     include Search
     include GovernmentServices
     include PostOfficeBoxes
+    include Parcel24Locations
 
     BASE_URL = "https://cypruspost.post/api/postal-codes/"
 

--- a/lib/cyprus_postal_codes/client.rb
+++ b/lib/cyprus_postal_codes/client.rb
@@ -16,8 +16,7 @@ module CyprusPostalCodes
     include Search
 
     BASE_URL = "https://cypruspost.post/api/postal-codes/"
-
-    attr_reader :api_key, :lng
+    private_constant :BASE_URL
 
     def initialize(api_key:, lng: "el")
       @api_key = api_key
@@ -33,11 +32,13 @@ module CyprusPostalCodes
       @last_response if defined?(@last_response)
     end
 
+    private
+
+    attr_reader :api_key, :lng
+
     def default_params
       { lng: lng }
     end
-
-    private
 
     def connection
       @connection ||= Faraday.new do |conn|

--- a/lib/cyprus_postal_codes/client.rb
+++ b/lib/cyprus_postal_codes/client.rb
@@ -9,6 +9,7 @@ module CyprusPostalCodes
     include Paginator
     include Areas
     include Districts
+    include Search
 
     BASE_URL = "https://cypruspost.post/api/postal-codes/"
 

--- a/lib/cyprus_postal_codes/client.rb
+++ b/lib/cyprus_postal_codes/client.rb
@@ -10,6 +10,7 @@ module CyprusPostalCodes
     include Areas
     include Districts
     include Search
+    include GovernmentServices
 
     BASE_URL = "https://cypruspost.post/api/postal-codes/"
 

--- a/lib/cyprus_postal_codes/client/government_services.rb
+++ b/lib/cyprus_postal_codes/client/government_services.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module CyprusPostalCodes
+  class Client
+    module GovernmentServices
+      def government_services(param:, district: nil, page_token: nil)
+        get("government-services", param: param, district: district, page_token: page_token)
+      end
+    end
+  end
+end

--- a/lib/cyprus_postal_codes/client/occupied_areas.rb
+++ b/lib/cyprus_postal_codes/client/occupied_areas.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module CyprusPostalCodes
+  class Client
+    module OccupiedAreas
+      def occupied_areas(district: nil, param: nil, page_token: nil)
+        get("occupied-areas", district: district, param: param, page_token: page_token)
+      end
+    end
+  end
+end

--- a/lib/cyprus_postal_codes/client/paginator.rb
+++ b/lib/cyprus_postal_codes/client/paginator.rb
@@ -3,6 +3,9 @@
 module CyprusPostalCodes
   class Client
     module Paginator
+      RESOURCES = %w[addresses result].freeze
+      private_constant :RESOURCES
+
       def next_page
         paginator&.dig("tokens", "next_page")
       end
@@ -17,14 +20,12 @@ module CyprusPostalCodes
 
       private
 
-      RESOURCE_INDEX = 2
-
       def paginator
-        @paginator = last_response&.body&.dig("data", resource, "paginator")
+        @paginator = last_response&.body&.dig("data", resource&.join, "paginator")
       end
 
       def resource
-        last_response&.body&.dig("data")&.keys&.fetch(RESOURCE_INDEX)
+        last_response&.body&.dig("data")&.keys & RESOURCES
       end
     end
   end

--- a/lib/cyprus_postal_codes/client/paginator.rb
+++ b/lib/cyprus_postal_codes/client/paginator.rb
@@ -14,8 +14,20 @@ module CyprusPostalCodes
         paginator&.dig("tokens", "previous_page")
       end
 
+      def first_page
+        paginator&.dig("tokens", "first_page")
+      end
+
+      def last_page
+        paginator&.dig("tokens", "last_page")
+      end
+
       def total_pages
         paginator&.fetch("total_pages") || 0
+      end
+
+      def total_count
+        paginator&.fetch("total_count") || 0
       end
 
       private

--- a/lib/cyprus_postal_codes/client/parcel24_locations.rb
+++ b/lib/cyprus_postal_codes/client/parcel24_locations.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module CyprusPostalCodes
+  class Client
+    module Parcel24Locations
+      def parcel24_locations(district: nil, param: nil, page_token: nil)
+        get("parcel24-locations", district: district, param: param, page_token: page_token)
+      end
+    end
+  end
+end

--- a/lib/cyprus_postal_codes/client/post_office_boxes.rb
+++ b/lib/cyprus_postal_codes/client/post_office_boxes.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module CyprusPostalCodes
+  class Client
+    module PostOfficeBoxes
+      def post_office_boxes(number:, page_token: nil)
+        get("post-office-boxes", number: number, page_token: page_token)
+      end
+    end
+  end
+end

--- a/lib/cyprus_postal_codes/client/search.rb
+++ b/lib/cyprus_postal_codes/client/search.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module CyprusPostalCodes
+  class Client
+    module Search
+      def search(district:, param:, area: nil)
+        get("search", district: district, param: param, area: area)
+      end
+    end
+  end
+end

--- a/lib/cyprus_postal_codes/client/search.rb
+++ b/lib/cyprus_postal_codes/client/search.rb
@@ -3,8 +3,8 @@
 module CyprusPostalCodes
   class Client
     module Search
-      def search(district:, param:, area: nil)
-        get("search", district: district, param: param, area: area)
+      def search(district:, param:, area: nil, page_token: nil)
+        get("search", district: district, param: param, area: area, page_token: page_token)
       end
     end
   end

--- a/spec/cyprus_postal_codes/client/addresses_spec.rb
+++ b/spec/cyprus_postal_codes/client/addresses_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe CyprusPostalCodes::Client::Addresses do
       expect(service).to have_received(:get).with("addresses", postal_code: 8020, page_token: nil)
     end
 
-    it "expects the post_code to be set" do
+    it "expects `post_code` to be set" do
       expect { service.addresses }.to raise_error(ArgumentError, "missing keyword: :post_code")
     end
   end

--- a/spec/cyprus_postal_codes/client/areas_spec.rb
+++ b/spec/cyprus_postal_codes/client/areas_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe CyprusPostalCodes::Client::Areas do
       expect(service).to have_received(:get).with("get-areas", district: "lefkosia", page_token: nil)
     end
 
-    it "expects the district to be set" do
+    it "expects `district` to be set" do
       expect { service.areas }.to raise_error(ArgumentError, "missing keyword: :district")
     end
   end

--- a/spec/cyprus_postal_codes/client/government_services_spec.rb
+++ b/spec/cyprus_postal_codes/client/government_services_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+RSpec.describe CyprusPostalCodes::Client::GovernmentServices do
+  describe "government_services" do
+    subject(:client) do
+      Class.new do
+        include CyprusPostalCodes::Client::GovernmentServices
+
+        def get(resource, options); end
+      end
+    end
+
+    before { stub_const("GovernmentServicesClient", client) }
+
+    let(:service) { GovernmentServicesClient.new }
+
+    it "calls the `government-services` endpoint" do
+      allow(service).to receive(:get)
+
+      service.government_services(param: "arc")
+
+      expect(service).to have_received(:get).with("government-services", param: "arc", district: nil, page_token: nil)
+    end
+
+    it "expects `district` to be set" do
+      expect { service.government_services }.to raise_error(ArgumentError, "missing keyword: :param")
+    end
+  end
+end

--- a/spec/cyprus_postal_codes/client/occupied_areas_spec.rb
+++ b/spec/cyprus_postal_codes/client/occupied_areas_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec.describe CyprusPostalCodes::Client::OccupiedAreas do
+  describe "occupied_areas" do
+    subject(:client) do
+      Class.new do
+        include CyprusPostalCodes::Client::OccupiedAreas
+
+        def get(resource, options); end
+      end
+    end
+
+    before { stub_const("OccupiedAreasClient", client) }
+
+    let(:service) { OccupiedAreasClient.new }
+
+    it "calls the `occupied-areas` endpoint" do
+      allow(service).to receive(:get)
+
+      service.occupied_areas
+
+      expect(service).to have_received(:get).with("occupied-areas", district: nil, param: nil, page_token: nil)
+    end
+  end
+end

--- a/spec/cyprus_postal_codes/client/paginator_spec.rb
+++ b/spec/cyprus_postal_codes/client/paginator_spec.rb
@@ -22,10 +22,13 @@ RSpec.describe CyprusPostalCodes::Client::Paginator do
           "language" => "el",
           "addresses" =>
           { "paginator" =>
-            { "total_pages" => "12",
+            { "total_count" => "100",
+              "total_pages" => "12",
               "tokens" =>
               { "next_page" => "next_page_token",
-                "previous_page" => "previous_page_token" } } } } }
+                "previous_page" => "previous_page_token",
+                "first_page" => "first_page_token",
+                "last_page" => "last_page_token" } } } } }
     end
 
     describe "next_page" do
@@ -96,10 +99,13 @@ RSpec.describe CyprusPostalCodes::Client::Paginator do
           "language" => "el",
           "result" =>
           { "paginator" =>
-            { "total_pages" => "12",
+            { "total_count" => "100",
+              "total_pages" => "12",
               "tokens" =>
               { "next_page" => "next_page_token",
-                "previous_page" => "previous_page_token" } } } } }
+                "previous_page" => "previous_page_token",
+                "first_page" => "first_page_token",
+                "last_page" => "last_page_token" } } } } }
     end
 
     describe "next_page" do
@@ -172,10 +178,13 @@ RSpec.describe CyprusPostalCodes::Client::Paginator do
           "language" => "el",
           "result" =>
           { "paginator" =>
-            { "total_pages" => "12",
+            { "total_count" => "100",
+              "total_pages" => "12",
               "tokens" =>
               { "next_page" => "next_page_token",
-                "previous_page" => "previous_page_token" } } } } }
+                "previous_page" => "previous_page_token",
+                "first_page" => "first_page_token",
+                "last_page" => "last_page_token" } } } } }
     end
 
     describe "next_page" do

--- a/spec/cyprus_postal_codes/client/paginator_spec.rb
+++ b/spec/cyprus_postal_codes/client/paginator_spec.rb
@@ -89,8 +89,8 @@ RSpec.describe CyprusPostalCodes::Client::Paginator do
     end
   end
 
-  describe "when using the other resource" do
-    let(:other_paginator_data) do
+  describe "when using the areas resource" do
+    let(:areas_paginator_data) do
       { "data" =>
         { "postal_code" => "1111",
           "language" => "el",
@@ -112,10 +112,10 @@ RSpec.describe CyprusPostalCodes::Client::Paginator do
       end
 
       context "when there is a last response" do
-        let(:paginator_service) { Paginator.new(other_paginator_data) }
+        let(:paginator_service) { Paginator.new(areas_paginator_data) }
 
         it "returns the next page token" do
-          paginator_service = Paginator.new(other_paginator_data)
+          paginator_service = Paginator.new(areas_paginator_data)
 
           expect(paginator_service.next_page).to eq("next_page_token")
         end
@@ -132,10 +132,10 @@ RSpec.describe CyprusPostalCodes::Client::Paginator do
       end
 
       context "when there is a last response" do
-        let(:paginator_service) { Paginator.new(other_paginator_data) }
+        let(:paginator_service) { Paginator.new(areas_paginator_data) }
 
         it "returns the previous page token" do
-          paginator_service = Paginator.new(other_paginator_data)
+          paginator_service = Paginator.new(areas_paginator_data)
 
           expect(paginator_service.previous_page).to eq("previous_page_token")
         end
@@ -152,10 +152,86 @@ RSpec.describe CyprusPostalCodes::Client::Paginator do
       end
 
       context "when there is a last response" do
-        let(:paginator_service) { Paginator.new(other_paginator_data) }
+        let(:paginator_service) { Paginator.new(areas_paginator_data) }
 
         it "returns the total_pages field value" do
-          paginator_service = Paginator.new(other_paginator_data)
+          paginator_service = Paginator.new(areas_paginator_data)
+
+          expect(paginator_service.total_pages).to eq("12")
+        end
+      end
+    end
+  end
+
+  describe "when using the search resource" do
+    let(:search_paginator_data) do
+      { "data" =>
+        { "district" => "larnaka",
+          "area" => nil,
+          "param" => "arch",
+          "language" => "el",
+          "result" =>
+          { "paginator" =>
+            { "total_pages" => "12",
+              "tokens" =>
+              { "next_page" => "next_page_token",
+                "previous_page" => "previous_page_token" } } } } }
+    end
+
+    describe "next_page" do
+      context "when there is no last response" do
+        let(:paginator_service) { Paginator.new }
+
+        it "returns nil" do
+          expect(paginator_service.next_page).to be nil
+        end
+      end
+
+      context "when there is a last response" do
+        let(:paginator_service) { Paginator.new(search_paginator_data) }
+
+        it "returns the next page token" do
+          paginator_service = Paginator.new(search_paginator_data)
+
+          expect(paginator_service.next_page).to eq("next_page_token")
+        end
+      end
+    end
+
+    describe "previous_page" do
+      context "when there is no last response" do
+        let(:paginator_service) { Paginator.new }
+
+        it "returns nil" do
+          expect(paginator_service.previous_page).to be nil
+        end
+      end
+
+      context "when there is a last response" do
+        let(:paginator_service) { Paginator.new(search_paginator_data) }
+
+        it "returns the previous page token" do
+          paginator_service = Paginator.new(search_paginator_data)
+
+          expect(paginator_service.previous_page).to eq("previous_page_token")
+        end
+      end
+    end
+
+    describe "total_pages" do
+      context "when there is no last response" do
+        let(:paginator_service) { Paginator.new }
+
+        it "returns zero" do
+          expect(paginator_service.total_pages).to eq(0)
+        end
+      end
+
+      context "when there is a last response" do
+        let(:paginator_service) { Paginator.new(search_paginator_data) }
+
+        it "returns the total_pages field value" do
+          paginator_service = Paginator.new(search_paginator_data)
 
           expect(paginator_service.total_pages).to eq("12")
         end

--- a/spec/cyprus_postal_codes/client/parcel24_locations_spec.rb
+++ b/spec/cyprus_postal_codes/client/parcel24_locations_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec.describe CyprusPostalCodes::Client::Parcel24Locations do
+  describe "parcel24_locations" do
+    subject(:client) do
+      Class.new do
+        include CyprusPostalCodes::Client::Parcel24Locations
+
+        def get(resource, options); end
+      end
+    end
+
+    before { stub_const("Parcel24LocationsClient", client) }
+
+    let(:service) { Parcel24LocationsClient.new }
+
+    it "calls the `parcel24-locations` endpoint" do
+      allow(service).to receive(:get)
+
+      service.parcel24_locations
+
+      expect(service).to have_received(:get).with("parcel24-locations", district: nil, param: nil, page_token: nil)
+    end
+  end
+end

--- a/spec/cyprus_postal_codes/client/post_office_boxes_spec.rb
+++ b/spec/cyprus_postal_codes/client/post_office_boxes_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+RSpec.describe CyprusPostalCodes::Client::PostOfficeBoxes do
+  describe "post_office_boxes" do
+    subject(:client) do
+      Class.new do
+        include CyprusPostalCodes::Client::PostOfficeBoxes
+
+        def get(resource, options); end
+      end
+    end
+
+    before { stub_const("PostOfficeBoxesClient", client) }
+
+    let(:service) { PostOfficeBoxesClient.new }
+
+    it "calls the `post-office-boxes` endpoint" do
+      allow(service).to receive(:get)
+
+      service.post_office_boxes(number: 12_220)
+
+      expect(service).to have_received(:get).with("post-office-boxes", number: 12_220, page_token: nil)
+    end
+
+    it "expects `number` to be set" do
+      expect { service.post_office_boxes }.to raise_error(ArgumentError, "missing keyword: :number")
+    end
+  end
+end

--- a/spec/cyprus_postal_codes/client/search_spec.rb
+++ b/spec/cyprus_postal_codes/client/search_spec.rb
@@ -19,7 +19,8 @@ RSpec.describe CyprusPostalCodes::Client::Search do
 
       service.search(district: "lefkosia", param: "arch")
 
-      expect(service).to have_received(:get).with("search", district: "lefkosia", param: "arch", area: nil)
+      expect(service).to have_received(:get).with("search", district: "lefkosia", param: "arch", area: nil,
+                                                            page_token: nil)
     end
 
     it "expects `district` and `param` to be set" do

--- a/spec/cyprus_postal_codes/client/search_spec.rb
+++ b/spec/cyprus_postal_codes/client/search_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+RSpec.describe CyprusPostalCodes::Client::Search do
+  describe "search" do
+    subject(:client) do
+      Class.new do
+        include CyprusPostalCodes::Client::Search
+
+        def get(resource, options); end
+      end
+    end
+
+    before { stub_const("SearchClient", client) }
+
+    let(:service) { SearchClient.new }
+
+    it "calls the `search` endpoint" do
+      allow(service).to receive(:get)
+
+      service.search(district: "lefkosia", param: "arch")
+
+      expect(service).to have_received(:get).with("search", district: "lefkosia", param: "arch", area: nil)
+    end
+
+    it "expects `district` and `param` to be set" do
+      expect { service.search }.to raise_error(ArgumentError, "missing keywords: :district, :param")
+    end
+
+    it "expects `district` to be set" do
+      expect { service.search(param: "arch") }.to raise_error(ArgumentError, "missing keyword: :district")
+    end
+
+    it "expects `param` to be set" do
+      expect { service.search(district: "lefkosia") }.to raise_error(ArgumentError, "missing keyword: :param")
+    end
+  end
+end


### PR DESCRIPTION
- Add search endpoint
- Handle search pagination
- Add government-services resource with pagination
- Add post-office-boxes resource with pagination
- Add parcel24-locations resource with pagination
- Add occupied_areas resource with pagination
- Sort alphabetically
- No longer needed
- Add more helpful methods to the paginator
- Refactor client
- Run rubocop before rspec